### PR TITLE
Listen for UDP packets on all network interfaces

### DIFF
--- a/transport/udp.go
+++ b/transport/udp.go
@@ -53,7 +53,7 @@ func NewUdp(messageHandler MessageHandler, localPort int) Udp {
 
 	u.localPort = localPort
 	util.Log.Printf("binding udp socket to port %d.\n", localPort)
-	u.listener, _ = net.ListenPacket("udp", "0.0.0.0:"+portStr)
+	u.listener, _ = net.ListenPacket("udp", ":"+portStr)
 	return u
 }
 


### PR DESCRIPTION
GGPO-Go specifies the address `0.0.0.0` which only allows local connections.  To also allow external connections, no address should be specified.

`net.ListenPacket` docs:

```
// See func Dial for a description of the network and address
// parameters.
```

`net.Dial` docs:

```
// For TCP, UDP and IP networks, if the host is empty or a literal
// unspecified IP address, as in ":80", "0.0.0.0:80" or "[::]:80" for
// TCP and UDP, "", "0.0.0.0" or "::" for IP, the local system is
// assumed.
```